### PR TITLE
Enable logging in most important catch phrases

### DIFF
--- a/src/main/java/eu/timerertim/downlomatic/core/download/Download.java
+++ b/src/main/java/eu/timerertim/downlomatic/core/download/Download.java
@@ -1,5 +1,6 @@
 package eu.timerertim.downlomatic.core.download;
 
+import eu.timerertim.downlomatic.utils.logging.Log;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -340,7 +341,8 @@ public class Download {
         downloaded = getDownloaded();
         try {
             src.close();
-        } catch (IOException ignored) {
+        } catch (IOException ex) {
+            Log.w("Source ByteChannel could not be closed", ex);
         } finally {
             src = null;
         }

--- a/src/main/java/eu/timerertim/downlomatic/core/framework/Downloader.java
+++ b/src/main/java/eu/timerertim/downlomatic/core/framework/Downloader.java
@@ -3,6 +3,7 @@ package eu.timerertim.downlomatic.core.framework;
 import com.google.common.io.Files;
 import eu.timerertim.downlomatic.core.download.Download;
 import eu.timerertim.downlomatic.core.format.EpisodeFormat;
+import eu.timerertim.downlomatic.utils.logging.Log;
 import javafx.util.Pair;
 
 import java.io.File;
@@ -106,7 +107,7 @@ public abstract class Downloader {
                 Files.createParentDirs(file);
                 download = new Download(videoURL, file, onRead);
             } catch (IOException e) {
-                download = null;
+                Log.e("Download could not be created.", e);
             }
             return download;
         }

--- a/src/main/java/eu/timerertim/downlomatic/core/framework/Host.java
+++ b/src/main/java/eu/timerertim/downlomatic/core/framework/Host.java
@@ -1,5 +1,7 @@
 package eu.timerertim.downlomatic.core.framework;
 
+import eu.timerertim.downlomatic.utils.logging.Log;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedHashSet;
@@ -24,6 +26,7 @@ public abstract class Host implements Page {
         try {
             listURL = getListURL();
         } catch (MalformedURLException e) {
+            Log.wtf(getPageDomain() + " Host has no valid URL to parse Series from.", e);
             listURL = null;
         }
         this.listURL = listURL;

--- a/src/main/java/eu/timerertim/downlomatic/core/framework/Series.java
+++ b/src/main/java/eu/timerertim/downlomatic/core/framework/Series.java
@@ -1,5 +1,7 @@
 package eu.timerertim.downlomatic.core.framework;
 
+import eu.timerertim.downlomatic.utils.logging.Log;
+
 import javax.annotation.Nonnull;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -123,6 +125,7 @@ public abstract class Series implements Iterable<Downloader> {
                 }
             };
         } catch (MalformedURLException e) {
+            Log.wtf("Custom Series has invalid seriesURL. That's logically not possible.", e);
             return null;
         }
     }


### PR DESCRIPTION
# Enable logging in most important catch phrases

## Description

Now that the project has a logging framework, it was time to put it in use. The most critical catch phrases are handled with logging now. As the project gets refactored over time, more and more suitable log actions will be added.

Fixes #2 


@TimerErTim
